### PR TITLE
fix: Do not throw if access list is empty

### DIFF
--- a/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlp/txn/RlpTxnChunk.java
+++ b/arithmetization/src/main/java/net/consensys/linea/zktracer/module/rlp/txn/RlpTxnChunk.java
@@ -124,7 +124,7 @@ public final class RlpTxnChunk extends ModuleOperation {
 
     // Phase 10: AccessList
     if (txType == 1 || txType == 2) {
-      if (this.tx.getAccessList().orElseThrow().isEmpty()) {
+      if (this.tx.getAccessList().isEmpty() || this.tx.getAccessList().get().isEmpty()) {
         rowSize += 1;
       } else {
         // Rlp prefix of the AccessList list


### PR DESCRIPTION
In some cases, for example, when the transaction is created for a simulation, Besu can have a transaction of type 2 in which the accessesList is empty.

That check prevents the module line count on ZkTracer when the transaction comes from linea_estimateGas.

related to https://github.com/Consensys/linea-sequencer/pull/1
